### PR TITLE
Setting default disposition to first audio stream.

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -92,9 +92,9 @@ class PluginStreamMapper(StreamMapper):
             # Process streams of interest
             self.found_search_string_streams = True
             if self.test_tags_for_search_string(stream_info.get('tags')):
-                self.search_string_stream_mapping += ['-map', '0:{}:{}'.format(ident.get(codec_type), stream_id)]
+                self.search_string_stream_mapping += ['-map', '0:{}:{}'.format(ident.get(codec_type), stream_id), '-disposition:{}:{}'.format(ident.get(codec_type), stream_id), 'default']
             else:
-                self.unmatched_stream_mapping += ['-map', '0:{}:{}'.format(ident.get(codec_type), stream_id)]
+                self.unmatched_stream_mapping += ['-map', '0:{}:{}'.format(ident.get(codec_type), stream_id), '-disposition:{}:{}'.format(ident.get(codec_type), stream_id), '0']
         else:
             # Process streams not of interest
             if not self.found_search_string_streams:


### PR DESCRIPTION
Trying to fix Unmanic/unmanic#238

Did a test with and without the changes

## Original
```
Stream #0:1(spa): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 220 kb/s (default)
Stream #0:2(eng): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 128 kb/s
```

## Processed without changes
```
Stream #0:1(eng): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 128 kb/s
Stream #0:2(spa): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 220 kb/s (default)
```
See how english stream is now first but the spanish one is still the default one.

## Processed with fork changes
```
Stream #0:1(eng): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 128 kb/s (default)
Stream #0:2(spa): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 220 kb/s
```
With changes first stream is default (and all the rest are cleaned of the default property, I've seen files with multiple default streams).
