### PR TITLE
Supporting multiple streams with selected language

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -92,7 +92,10 @@ class PluginStreamMapper(StreamMapper):
             # Process streams of interest
             self.found_search_string_streams = True
             if self.test_tags_for_search_string(stream_info.get('tags')):
-                self.search_string_stream_mapping += ['-map', '0:{}:{}'.format(ident.get(codec_type), stream_id), '-disposition:{}:{}'.format(ident.get(codec_type), stream_id), 'default']
+                disposition = '0'
+                if len(self.search_string_stream_mapping) == 0:
+                    disposition = 'default'
+                self.search_string_stream_mapping += ['-map', '0:{}:{}'.format(ident.get(codec_type), stream_id), '-disposition:{}:{}'.format(ident.get(codec_type), stream_id), disposition]
             else:
                 self.unmatched_stream_mapping += ['-map', '0:{}:{}'.format(ident.get(codec_type), stream_id), '-disposition:{}:{}'.format(ident.get(codec_type), stream_id), '0']
         else:


### PR DESCRIPTION
Turns out that changes introduced in #1 didn't support multiple streams with the selected language; so, when this was the case, the result was something like this:
```
Stream #0:1(spa): Audio: aac (LC), 48000 Hz, stereo, fltp (default)
Stream #0:2(spa): Audio: aac (LC), 48000 Hz, stereo, fltp (default)
Stream #0:3(spa): Audio: aac (LC), 48000 Hz, stereo, fltp (default)
Stream #0:4(eng): Audio: aac (LC), 48000 Hz, stereo, fltp
```

With changes from this PR, the result for the same file would be:
```
Stream #0:1(spa): Audio: aac (LC), 48000 Hz, stereo, fltp (default)
Stream #0:2(spa): Audio: aac (LC), 48000 Hz, stereo, fltp
Stream #0:3(spa): Audio: aac (LC), 48000 Hz, stereo, fltp
Stream #0:4(eng): Audio: aac (LC), 48000 Hz, stereo, fltp
```

Sorry for the new bug :D